### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -44,7 +44,7 @@ packOneByte	KEYWORD2
 packOneInt	KEYWORD2
 packOneFloat	KEYWORD2
 packOneLong	KEYWORD2
-packOneString KEYWORD2
+packOneString	KEYWORD2
 
 streamEmpty	KEYWORD2
 streamOneByte	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords